### PR TITLE
fix: extract color param from ansi.Param

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -152,7 +152,7 @@ func readColor(idxp *int, params []int) (c ansi.Color) {
 		return
 	}
 	// Note: we accept both main and subparams here
-	switch param := ansi.Param(params[i+1]); param {
+	switch param := ansi.Param(params[i+1]); param.Param() {
 	case 2: // RGB
 		if i > paramsLen-4 {
 			return

--- a/writer_test.go
+++ b/writer_test.go
@@ -101,8 +101,8 @@ var writer_cases = []struct {
 	},
 	{
 		name:              "simple ansi 256 color bg",
-		input:             "hello \x1b[48;5;196mworld\x1b[m",
-		expectedTrueColor: "hello \x1b[48;5;196mworld\x1b[m",
+		input:             "hello \x1b[48:5:196mworld\x1b[m",
+		expectedTrueColor: "hello \x1b[48:5:196mworld\x1b[m",
 		expectedANSI256:   "hello \x1b[48;5;196mworld\x1b[m",
 		expectedANSI:      "hello \x1b[101mworld\x1b[m",
 		expectedAscii:     "hello \x1b[mworld\x1b[m",


### PR DESCRIPTION
Add test to ensure we parse colon separated color params correctly.