### PR TITLE
feat: support adaptive colors extension

### DIFF
--- a/examples/writer/writer.go
+++ b/examples/writer/writer.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	w := colorprofile.NewWriter(os.Stdout, os.Environ())
+	w.SetHasDarkBackground(false)
 
 	// Read from stdin and write to stdout
 	bts, err := io.ReadAll(os.Stdin)


### PR DESCRIPTION
This will choose the color based on the `HasLightBackground` value of the writer. This is useful for supporting the adaptive colors extension in the terminal.

Extension specs:

SGR already defines 5 and 2 for 16 and 24-bit colors to be used with the 38, 48, and 58 parameters. This extension adds support for adaptive colors, which will choose the color based on the HasLightBackground value of the writer.

The 4 parameter is used to specify light-dark 24-bit colors.

```
printf '\x1b[38;4;255;0;0;0;255;0mHello, world!\x1b[0m\n'
```

Here the first three values are the light color and the last three values are the dark color.

The 10 parameter is used to specify light-dark 256 colors.

```
printf '\x1b[38;10;255;0mHello, world!\x1b[0m\n'
```