### PR TITLE
fix: minor typo in grayscale conversion

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -100,7 +100,7 @@ func hexToANSI256Color(c colorful.Color) ansi.ExtendedColor {
 
 	// Calculate the nearest 0-based gray index at 232..255
 	var grayIdx int
-	average := (r + g + b) / 3
+	average := (cr + cg + cb) / 3
 	if average > 238 {
 		grayIdx = 23
 	} else {

--- a/profile_test.go
+++ b/profile_test.go
@@ -1,53 +1,67 @@
 package colorprofile
 
 import (
+	"testing"
+
 	"github.com/charmbracelet/x/ansi"
 	"github.com/lucasb-eyer/go-colorful"
-	"testing"
 )
 
 func TestHexTo256(t *testing.T) {
 	testCases := map[string]struct {
 		input          colorful.Color
+		expectedHex    string
 		expectedOutput ansi.ExtendedColor
 	}{
 		"white": {
-			input:          colorful.Color{1, 1, 1},
+			input:          colorful.Color{R: 1, G: 1, B: 1},
+			expectedHex:    "#ffffff",
 			expectedOutput: 231,
 		},
 		"offwhite": {
-			input:          colorful.Color{0.9333, 0.9333, 0.933},
+			input:          colorful.Color{R: 0.9333, G: 0.9333, B: 0.933},
+			expectedHex:    "#eeeeee",
 			expectedOutput: 255,
 		},
 		"slightly brighter than offwhite": {
-			input:          colorful.Color{0.95, 0.95, 0.95},
+			input:          colorful.Color{R: 0.95, G: 0.95, B: 0.95},
+			expectedHex:    "#f2f2f2",
 			expectedOutput: 255,
 		},
 		"red": {
-			input:          colorful.Color{1, 0, 0},
+			input:          colorful.Color{R: 1, G: 0, B: 0},
+			expectedHex:    "#ff0000",
 			expectedOutput: 196,
 		},
 		"silver foil": {
-			input:          colorful.Color{0.6863, 0.6863, 0.6863},
+			input:          colorful.Color{R: 0.6863, G: 0.6863, B: 0.6863},
+			expectedHex:    "#afafaf",
 			expectedOutput: 145,
 		},
 		"silver chalice": {
-			input:          colorful.Color{0.698, 0.698, 0.698},
+			input:          colorful.Color{R: 0.698, G: 0.698, B: 0.698},
+			expectedHex:    "#b2b2b2",
 			expectedOutput: 249,
 		},
 		"slightly closer to silver foil": {
-			input:          colorful.Color{0.692, 0.692, 0.692},
+			input:          colorful.Color{R: 0.692, G: 0.692, B: 0.692},
+			expectedHex:    "#b0b0b0",
 			expectedOutput: 145,
 		},
 		"slightly closer to silver chalice": {
-			input:          colorful.Color{0.694, 0.694, 0.694},
+			input:          colorful.Color{R: 0.694, G: 0.694, B: 0.694},
+			expectedHex:    "#b1b1b1",
 			expectedOutput: 249,
 		},
 	}
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
+			// hex := fmt.Sprintf("#%02x%02x%02x", uint8(testCase.input.R*255), uint8(testCase.input.G*255), uint8(testCase.input.B*255))
 			output := hexToANSI256Color(testCase.input)
+			if testCase.input.Hex() != testCase.expectedHex {
+				t.Errorf("Expected %+v to map to %s, but instead received %s", testCase.input, testCase.expectedHex, testCase.input.Hex())
+			}
 			if output != testCase.expectedOutput {
 				t.Errorf("Expected truecolor %+v to map to 256 color %d, but instead received %d", testCase.input, testCase.expectedOutput, output)
 			}

--- a/profile_test.go
+++ b/profile_test.go
@@ -1,0 +1,56 @@
+package colorprofile
+
+import (
+	"github.com/charmbracelet/x/ansi"
+	"github.com/lucasb-eyer/go-colorful"
+	"testing"
+)
+
+func TestHexTo256(t *testing.T) {
+	testCases := map[string]struct {
+		input          colorful.Color
+		expectedOutput ansi.ExtendedColor
+	}{
+		"white": {
+			input:          colorful.Color{1, 1, 1},
+			expectedOutput: 231,
+		},
+		"offwhite": {
+			input:          colorful.Color{0.9333, 0.9333, 0.933},
+			expectedOutput: 255,
+		},
+		"slightly brighter than offwhite": {
+			input:          colorful.Color{0.95, 0.95, 0.95},
+			expectedOutput: 255,
+		},
+		"red": {
+			input:          colorful.Color{1, 0, 0},
+			expectedOutput: 196,
+		},
+		"silver foil": {
+			input:          colorful.Color{0.6863, 0.6863, 0.6863},
+			expectedOutput: 145,
+		},
+		"silver chalice": {
+			input:          colorful.Color{0.698, 0.698, 0.698},
+			expectedOutput: 249,
+		},
+		"slightly closer to silver foil": {
+			input:          colorful.Color{0.692, 0.692, 0.692},
+			expectedOutput: 145,
+		},
+		"slightly closer to silver chalice": {
+			input:          colorful.Color{0.694, 0.694, 0.694},
+			expectedOutput: 249,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			output := hexToANSI256Color(testCase.input)
+			if output != testCase.expectedOutput {
+				t.Errorf("Expected truecolor %+v to map to 256 color %d, but instead received %d", testCase.input, testCase.expectedOutput, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The grayscale conversion takes 0..255 colors for the color indices determined in the first part of the algorithm and averages them and does some other stuff to convert them to a grayscale color.

Unfortunately, the existing code was taking the color indices instead of the 0..255 colors, which was causing the grayscale color to always be black, and rarely be chosen.  This fix will improve conversion of grayscale colors.