### PR TITLE
fix: add xterm and rio color profiles

### DIFF
--- a/env.go
+++ b/env.go
@@ -122,10 +122,18 @@ func envColorProfile(env map[string]string) (p Profile) {
 	switch term {
 	case "", "dumb":
 		p = NoTTY
-	case "alacritty", "contour", "wezterm", "xterm-ghostty", "xterm-kitty":
+	case "alacritty",
+		"contour",
+		"foot",
+		"ghostty",
+		"kitty",
+		"rio",
+		"wezterm",
+		"xterm-ghostty",
+		"xterm-kitty":
 		p = TrueColor
 		return
-	case "linux":
+	case "xterm", "linux":
 		p = ANSI
 	case "screen":
 		p = ANSI256
@@ -183,8 +191,6 @@ func envColorProfile(env map[string]string) (p Profile) {
 				return
 			} else if colors >= 0x100 && p > ANSI256 {
 				p = ANSI256
-			} else if colors >= 0x10 && p > ANSI {
-				p = ANSI
 			}
 		}
 	}

--- a/env.go
+++ b/env.go
@@ -201,6 +201,8 @@ func envColorProfile(env map[string]string) (p Profile) {
 				return
 			} else if colors >= 0x100 && p > ANSI256 {
 				p = ANSI256
+			} else if colors >= 0x10 && p > ANSI {
+				p = ANSI
 			}
 		}
 	}

--- a/env.go
+++ b/env.go
@@ -130,9 +130,7 @@ func envColorProfile(env map[string]string) (p Profile) {
 		"kitty",
 		"rio",
 		"st",
-		"wezterm",
-		"xterm-ghostty",
-		"xterm-kitty":
+		"wezterm":
 		return TrueColor
 	case "xterm":
 		for _, t := range []string{

--- a/env.go
+++ b/env.go
@@ -119,7 +119,8 @@ func colorTerm(env map[string]string) bool {
 func envColorProfile(env map[string]string) (p Profile) {
 	term, ok := env["TERM"]
 	term = strings.ToLower(term)
-	switch term {
+	parts := strings.Split(term, "-")
+	switch parts[0] {
 	case "", "dumb":
 		p = NoTTY
 	case "alacritty",
@@ -128,12 +129,23 @@ func envColorProfile(env map[string]string) (p Profile) {
 		"ghostty",
 		"kitty",
 		"rio",
+		"st",
 		"wezterm",
 		"xterm-ghostty",
 		"xterm-kitty":
-		p = TrueColor
-		return
-	case "xterm", "linux":
+		return TrueColor
+	case "xterm":
+		for _, t := range []string{
+			// These terminals can be defined as xterm-TERMNAME
+			"ghostty",
+			"kitty",
+		} {
+			if strings.Contains(term, "-"+t) {
+				return TrueColor
+			}
+		}
+		fallthrough
+	case "linux":
 		p = ANSI
 	case "screen":
 		p = ANSI256

--- a/env_test.go
+++ b/env_test.go
@@ -50,7 +50,14 @@ var cases = []struct {
 			"TERM=dumb",
 			"CLICOLOR_FORCE=1",
 		},
-		expected: ANSI,
+		expected: func() Profile {
+			if runtime.GOOS == "windows" {
+				// Windows Terminal supports TrueColor
+				return TrueColor
+			} else {
+				return ANSI
+			}
+		}(),
 	},
 	{
 		name: "dumb term, CLICOLOR=1",
@@ -180,8 +187,7 @@ var cases = []struct {
 			"TERM=tmux",
 			"COLORTERM=truecolor",
 		},
-		// TODO: Should this be ANSI256?
-		expected: Ascii,
+		expected: ANSI256,
 	},
 	{
 		name: "tmux 256color",

--- a/env_test.go
+++ b/env_test.go
@@ -96,7 +96,7 @@ var cases = []struct {
 		environ: []string{
 			"TERM=xterm",
 		},
-		expected: Ascii,
+		expected: ANSI,
 	},
 	{
 		name: "xterm, NO_COLOR=1",


### PR DESCRIPTION
This adds `TERM=rio` as a TrueColor profile and `TERM=xterm` as an ANSI profile.