### PR TITLE
feat: support terminfo databases and query tmux for color profile

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -50,7 +50,14 @@ var cases = []struct {
 			"TERM=dumb",
 			"CLICOLOR_FORCE=1",
 		},
-		expected: ANSI,
+		expected: func() Profile {
+			if runtime.GOOS == "windows" {
+				// Windows Terminal supports TrueColor
+				return TrueColor
+			} else {
+				return ANSI
+			}
+		}(),
 	},
 	{
 		name: "dumb term, CLICOLOR=1",
@@ -180,8 +187,7 @@ var cases = []struct {
 			"TERM=tmux",
 			"COLORTERM=truecolor",
 		},
-		// TODO: Should this be ANSI256?
-		expected: Ascii,
+		expected: ANSI256,
 	},
 	{
 		name: "tmux 256color",


### PR DESCRIPTION
This adds two new functions to detect the color profile based on the terminal's terminfo database and tmux configuration. The `Terminfo` function returns the color profile based on the terminal's terminfo database. This relies on the Tc and RGB capabilities to determine if the terminal supports TrueColor. The `Tmux` function returns the color profile based on `tmux info` output. Tmux supports overriding the terminal's terminfo database, so this function will return the color profile based on `tmux info` output which is taken from the tmux configurations.

Now, `Detect` will return the minimum of the color profile based on the environment, terminfo, and tmux. This ensures that the color profile is the most accurate based on the terminal's capabilities.

Environment variables take precedence over terminfo and tmux.