### PR TITLE
refactor: reorder color profiles

### DIFF
--- a/env.go
+++ b/env.go
@@ -80,17 +80,17 @@ func colorProfile(isatty bool, env environ) (p Profile) {
 	}
 
 	if envNoColor(env) && isatty {
-		if p < Ascii {
+		if p > Ascii {
 			p = Ascii
 		}
 		return
 	}
 
 	if cliColorForced(env) {
-		if p > ANSI {
+		if p < ANSI {
 			p = ANSI
 		}
-		if envp < p {
+		if envp > p {
 			p = envp
 		}
 
@@ -98,7 +98,7 @@ func colorProfile(isatty bool, env environ) (p Profile) {
 	}
 
 	if cliColor(env) {
-		if isatty && !isDumb && p > ANSI {
+		if isatty && !isDumb && p < ANSI {
 			p = ANSI
 		}
 	}
@@ -165,7 +165,7 @@ func envColorProfile(env environ) (p Profile) {
 			}
 		}
 	case "tmux", "screen":
-		if p > ANSI256 {
+		if p < ANSI256 {
 			p = ANSI256
 		}
 	}
@@ -180,7 +180,7 @@ func envColorProfile(env environ) (p Profile) {
 		return TrueColor
 	}
 
-	if strings.HasSuffix(term, "256color") && p > ANSI256 {
+	if strings.HasSuffix(term, "256color") && p < ANSI256 {
 		p = ANSI256
 	}
 

--- a/profile.go
+++ b/profile.go
@@ -12,16 +12,16 @@ import (
 type Profile byte
 
 const (
-	// TrueColor, 24-bit color profile.
-	TrueColor Profile = iota
-	// ANSI256, 8-bit color profile.
-	ANSI256
-	// ANSI, 4-bit color profile.
-	ANSI
+	// NoTTY, not a terminal profile.
+	NoTTY Profile = iota
 	// Ascii, uncolored profile.
 	Ascii //nolint:revive
-	// NoTTY, not a terminal profile.
-	NoTTY
+	// ANSI, 4-bit color profile.
+	ANSI
+	// ANSI256, 8-bit color profile.
+	ANSI256
+	// TrueColor, 24-bit color profile.
+	TrueColor
 )
 
 // String returns the string representation of a Profile.
@@ -43,7 +43,7 @@ func (p Profile) String() string {
 
 // Convert transforms a given Color to a Color supported within the Profile.
 func (p Profile) Convert(c color.Color) color.Color {
-	if p >= Ascii {
+	if p <= Ascii {
 		return nil
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -91,7 +91,7 @@ func handleSgr(w *Writer, p *ansi.Parser, buf *bytes.Buffer) {
 			// number of bytes written to the buffer.
 			style = append(style, "")
 		case 30, 31, 32, 33, 34, 35, 36, 37: // 8-bit foreground color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.ForegroundColor(
@@ -101,17 +101,17 @@ func handleSgr(w *Writer, p *ansi.Parser, buf *bytes.Buffer) {
 			if n := ansi.ReadStyleColor(params, &c); n > 0 {
 				i += n - 1
 			}
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.ForegroundColor(w.Profile.Convert(c))
 		case 39: // default foreground color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.DefaultForegroundColor()
 		case 40, 41, 42, 43, 44, 45, 46, 47: // 8-bit background color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.BackgroundColor(
@@ -121,12 +121,12 @@ func handleSgr(w *Writer, p *ansi.Parser, buf *bytes.Buffer) {
 			if n := ansi.ReadStyleColor(params, &c); n > 0 {
 				i += n - 1
 			}
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.BackgroundColor(w.Profile.Convert(c))
 		case 49: // default background color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.DefaultBackgroundColor()
@@ -135,23 +135,23 @@ func handleSgr(w *Writer, p *ansi.Parser, buf *bytes.Buffer) {
 			if n := ansi.ReadStyleColor(params, &c); n > 0 {
 				i += n - 1
 			}
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.UnderlineColor(w.Profile.Convert(c))
 		case 59: // default underline color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.DefaultUnderlineColor()
 		case 90, 91, 92, 93, 94, 95, 96, 97: // 8-bit bright foreground color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.ForegroundColor(
 				w.Profile.Convert(ansi.BasicColor(param - 90 + 8))) //nolint:gosec
 		case 100, 101, 102, 103, 104, 105, 106, 107: // 8-bit bright background color
-			if w.Profile > ANSI {
+			if w.Profile < ANSI {
 				continue
 			}
 			style = style.BackgroundColor(


### PR DESCRIPTION
This commit reorders the color profiles to start with the lowest profile, `NoTTY`, and end with the highest profile, `TrueColor`.

IMO, this makes the code easier to read and understand and makes the default value of `Profile` more intuitive.