### PR TITLE
fix: ignore COLORTERM when no TERM is defined

### DIFF
--- a/env.go
+++ b/env.go
@@ -192,6 +192,11 @@ func envColorProfile(env environ) (p Profile) {
 		p = ANSI256
 	}
 
+	// Direct color terminals support true colors.
+	if strings.HasSuffix(term, "direct") {
+		return TrueColor
+	}
+
 	return //nolint:nakedret
 }
 

--- a/env.go
+++ b/env.go
@@ -72,7 +72,7 @@ func Env(env []string) (p Profile) {
 
 func colorProfile(isatty bool, env environ) (p Profile) {
 	term, ok := env.lookup("TERM")
-	isDumb := !ok || term == dumbTerm
+	isDumb := (!ok && runtime.GOOS != "windows") || term == dumbTerm
 	envp := envColorProfile(env)
 	if !isatty || isDumb {
 		// Check if the output is a terminal.

--- a/env.go
+++ b/env.go
@@ -33,8 +33,8 @@ func Detect(output io.Writer, env []string) Profile {
 	out, ok := output.(term.File)
 	environ := newEnviron(env)
 	isatty := isTTYForced(environ) || (ok && term.IsTerminal(out.Fd()))
-	term := environ.get("TERM")
-	isDumb := term == dumbTerm
+	term, ok := environ.lookup("TERM")
+	isDumb := !ok || term == dumbTerm
 	envp := colorProfile(isatty, environ)
 	if envp == TrueColor || envNoColor(environ) {
 		// We already know we have TrueColor, or NO_COLOR is set.
@@ -71,7 +71,8 @@ func Env(env []string) (p Profile) {
 }
 
 func colorProfile(isatty bool, env environ) (p Profile) {
-	isDumb := env.get("TERM") == dumbTerm
+	term, ok := env.lookup("TERM")
+	isDumb := !ok || term == dumbTerm
 	envp := envColorProfile(env)
 	if !isatty || isDumb {
 		// Check if the output is a terminal.

--- a/env_test.go
+++ b/env_test.go
@@ -196,6 +196,20 @@ var cases = []struct {
 		},
 		expected: ANSI256,
 	},
+	{
+		name: "ignore COLORTERM when no TERM is defined",
+		environ: []string{
+			"COLORTERM=truecolor",
+		},
+		expected: func() Profile {
+			if runtime.GOOS == "windows" {
+				p, _ := windowsColorProfile(map[string]string{})
+				return p
+			} else {
+				return NoTTY
+			}
+		}(),
+	},
 }
 
 func TestEnvColorProfile(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -210,6 +210,13 @@ var cases = []struct {
 			}
 		}(),
 	},
+	{
+		name: "direct color xterm terminal",
+		environ: []string{
+			"TERM=xterm-direct",
+		},
+		expected: TrueColor,
+	},
 }
 
 func TestEnvColorProfile(t *testing.T) {


### PR DESCRIPTION
The `COLORTERM` environment variable _complements_ the `TERM` variable and should not be taken into consideration when `TERM` is not defined.