### PR TITLE
docs: fix contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ fmt.Fprintf(w, myFancyANSI) // not as fancy
 
 ## Contributing
 
-See [contributing][contribute].
-
-[contribute]: https://github.com/charmbracelet/colorprofile/contribute
+See [contributing](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
 
 ## Feedback
 


### PR DESCRIPTION
### Describe your changes

I just saw that the link for contributing leads to https://github.com/charmbracelet/colorprofile/contribute which showcases good first issues (currently none). This was done with https://github.com/charmbracelet/colorprofile/pull/47/.

However, I guess you might actually wanted to redirect to https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md ?

### Checklist before requesting a review

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my code
