### PR TITLE
fix: detect bash running in windows terminal

### DIFF
--- a/env.go
+++ b/env.go
@@ -173,6 +173,11 @@ func envColorProfile(env environ) (p Profile) {
 		}
 	}
 
+	if len(env["WT_SESSION"]) > 0 {
+		// Windows Terminal supports TrueColor
+		return TrueColor
+	}
+
 	if isCloudShell, _ := strconv.ParseBool(env.get("GOOGLE_CLOUD_SHELL")); isCloudShell {
 		return TrueColor
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -167,6 +167,17 @@ var cases = []struct {
 		}(),
 	},
 	{
+		name: "Windows Terminal bash.exe",
+		environ: []string{
+			"TERM=xterm-256color",
+			"WT_SESSION=1",
+		},
+		expected: func() Profile {
+			// Windows Terminal supports TrueColor
+			return TrueColor
+		}(),
+	},
+	{
 		name: "screen default",
 		environ: []string{
 			"TERM=screen",

--- a/env_windows.go
+++ b/env_windows.go
@@ -14,11 +14,6 @@ func windowsColorProfile(env map[string]string) (Profile, bool) {
 		return TrueColor, true
 	}
 
-	if len(env["WT_SESSION"]) > 0 {
-		// Windows Terminal supports TrueColor
-		return TrueColor, true
-	}
-
 	major, _, build := windows.RtlGetNtVersionNumbers()
 	if build < 10586 || major < 10 {
 		// No ANSI support before WindowsNT 10 build 10586


### PR DESCRIPTION
You can run any shell in Windows Terminal. Unlike traditional terminal emulators, Windows Terminal doesn't export TERM, or COLORTERM. Instead, it exports WT_SESSION to identify itself.

This commit adds support for detecting Windows Terminal when running any shell under Windows by checking for the presence of WT_SESSION. If WT_SESSION is present, we assume Windows Terminal is being used and that it supports true color.
