### PR TITLE
env: honor COLORTERM=truecolor inside tmux

### DIFF
--- a/env.go
+++ b/env.go
@@ -183,9 +183,11 @@ func envColorProfile(env environ) (p Profile) {
 		return TrueColor
 	}
 
-	// GNU Screen doesn't support TrueColor
-	// Tmux doesn't support $COLORTERM
-	if colorTerm(env) && !strings.HasPrefix(term, "screen") && !strings.HasPrefix(term, "tmux") {
+	// GNU Screen doesn't support TrueColor. Tmux did historically have the
+	// same limitation, which is why this used to exclude tmux as well, but
+	// modern tmux (3.2+) supports truecolor and propagates COLORTERM through
+	// to inner shells, so we should honor it. See #76.
+	if colorTerm(env) && !strings.HasPrefix(term, "screen") {
 		return TrueColor
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -193,15 +193,24 @@ var cases = []struct {
 		expected: ANSI256,
 	},
 	{
-		name: "tmux colorterm",
+		// Modern tmux propagates COLORTERM through to inner shells, see #76.
+		name: "tmux colorterm truecolor",
 		environ: []string{
 			"TERM=tmux",
 			"COLORTERM=truecolor",
 		},
-		expected: ANSI256,
+		expected: TrueColor,
 	},
 	{
-		name: "tmux 256color",
+		name: "tmux-256color colorterm truecolor",
+		environ: []string{
+			"TERM=tmux-256color",
+			"COLORTERM=truecolor",
+		},
+		expected: TrueColor,
+	},
+	{
+		name: "tmux 256color without colorterm stays ANSI256",
 		environ: []string{
 			"TERM=tmux-256color",
 		},


### PR DESCRIPTION
Closes #76.

\`envColorProfile\` excluded any TERM starting with \`tmux\` from the \`COLORTERM=truecolor\` upgrade with the comment "Tmux doesn't support \$COLORTERM". That was true once, but modern tmux (3.2+) supports truecolor and propagates COLORTERM through to inner shells. Sitting inside tmux with \`TERM=tmux-256color\` and \`COLORTERM=truecolor\` currently gets pinned at ANSI256 even though every wrapping terminal emulator correctly advertises truecolor.

Dropped the tmux exclusion. \`screen\` is kept on the deny-list because it still tops out at 256 colors in the wild.

Updated the existing \`tmux colorterm\` test to expect TrueColor and added one for the \`tmux-256color + COLORTERM=truecolor\` case from the issue, plus a no-COLORTERM regression to make sure tmux without truecolor still resolves to ANSI256.