### PR TITLE
env: honour FORCE_COLOR alongside CLICOLOR_FORCE

### DIFF
--- a/env.go
+++ b/env.go
@@ -123,8 +123,21 @@ func cliColor(env environ) bool {
 }
 
 func cliColorForced(env environ) bool {
-	cliColorForce, _ := strconv.ParseBool(env.get("CLICOLOR_FORCE"))
-	return cliColorForce
+	if v, _ := strconv.ParseBool(env.get("CLICOLOR_FORCE")); v {
+		return true
+	}
+	// FORCE_COLOR is the convention popularised by chalk / supports-color.
+	// https://force-color.org/. Any non-empty value other than "0" /
+	// "false" is interpreted as "force colour on".
+	if v := env.get("FORCE_COLOR"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+		if n, err := strconv.Atoi(v); err == nil {
+			return n > 0
+		}
+	}
+	return false
 }
 
 func isTTYForced(env environ) bool {

--- a/env_test.go
+++ b/env_test.go
@@ -68,6 +68,28 @@ var cases = []struct {
 		expected: NoTTY,
 	},
 	{
+		// #77: FORCE_COLOR=1 should force colour on, same as CLICOLOR_FORCE=1.
+		name: "dumb term, FORCE_COLOR=1",
+		environ: []string{
+			"TERM=dumb",
+			"FORCE_COLOR=1",
+		},
+		expected: func() Profile {
+			if runtime.GOOS == "windows" {
+				return TrueColor
+			}
+			return ANSI
+		}(),
+	},
+	{
+		name: "FORCE_COLOR=0 does not force",
+		environ: []string{
+			"TERM=dumb",
+			"FORCE_COLOR=0",
+		},
+		expected: NoTTY,
+	},
+	{
 		name: "xterm-256color",
 		environ: []string{
 			"TERM=xterm-256color",


### PR DESCRIPTION
Closes #77.

`FORCE_COLOR` is the convention popularised by chalk / supports-color and codified at https://force-color.org/. Treat it the same as `CLICOLOR_FORCE`: any non-empty value other than `0` / `false` forces colour on. The numeric variants (1/2/3) aren't yet mapped to profile tiers — this just hooks up the on/off switch, which covers the common Node-ecosystem case.